### PR TITLE
Remove references to org-global.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-linux:
-          context: org-global
-      - build-darwin:
-          context: org-global
+      - build-linux
+      - build-darwin


### PR DESCRIPTION
They're not used in Formation's CircleCI config.  Previously the build was failing with the error:
```Could not find context "org-global".```